### PR TITLE
Add workaround to build MIOpen with CK (ComposableKernel)

### DIFF
--- a/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
@@ -41,8 +41,9 @@ namespace ck_utility {
 /// instance for the device.
 static inline bool is_ck_whitelist(const std::string& device_name)
 {
-    return (StartsWith(device_name, "gfx908") || StartsWith(device_name, "gfx90a") ||
-            StartsWith(device_name, "gfx942") || StartsWith(device_name, "gfx950"));
+    return true;
+    // return (StartsWith(device_name, "gfx908") || StartsWith(device_name, "gfx90a") ||
+    //         StartsWith(device_name, "gfx942") || StartsWith(device_name, "gfx950"));
 }
 
 static inline bool is_ck_whitelist(const Handle& handle)

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -32,6 +32,13 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
+
+// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
+#ifdef MIOPEN_USE_COMPOSABLEKERNEL
+#undef MIOPEN_USE_COMPOSABLEKERNEL
+#define MIOPEN_USE_COMPOSABLEKERNEL 0
+#endif
+
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
 #include <ck/library/tensor_operation_instance/gpu/grouped_convolution_backward_data_bilinear.hpp>

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -32,6 +32,13 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
+
+// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
+#ifdef MIOPEN_USE_COMPOSABLEKERNEL
+#undef MIOPEN_USE_COMPOSABLEKERNEL
+#define MIOPEN_USE_COMPOSABLEKERNEL 0
+#endif
+
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
 #include <ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_bilinear.hpp>

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -32,6 +32,13 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
+
+// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
+#ifdef MIOPEN_USE_COMPOSABLEKERNEL
+#undef MIOPEN_USE_COMPOSABLEKERNEL
+#define MIOPEN_USE_COMPOSABLEKERNEL 0
+#endif
+
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <ck/library/tensor_operation_instance/gpu/convolution_backward_data.hpp>
 #include <miopen/solver/ck_utility_common.hpp>

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -32,6 +32,13 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
+
+// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
+#ifdef MIOPEN_USE_COMPOSABLEKERNEL
+#undef MIOPEN_USE_COMPOSABLEKERNEL
+#define MIOPEN_USE_COMPOSABLEKERNEL 0
+#endif
+
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <ck/library/tensor_operation_instance/gpu/convolution_forward.hpp>
 #include <miopen/solver/ck_utility_common.hpp>

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
@@ -34,6 +34,13 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
+
+// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
+#ifdef MIOPEN_USE_COMPOSABLEKERNEL
+#undef MIOPEN_USE_COMPOSABLEKERNEL
+#define MIOPEN_USE_COMPOSABLEKERNEL 0
+#endif
+
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp>
 #endif

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
@@ -34,6 +34,13 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
+
+// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
+#ifdef MIOPEN_USE_COMPOSABLEKERNEL
+#undef MIOPEN_USE_COMPOSABLEKERNEL
+#define MIOPEN_USE_COMPOSABLEKERNEL 0
+#endif
+
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
 #include <miopen/solver/implicitgemm_ck_util.hpp>


### PR DESCRIPTION
Add workaround to build MIOpen with CK (ComposableKernel)

A few solvers only support XDL instances and are not compatible with gfx1151. Therefore, we've implemented this workaround to bypass those specific solvers during the MIOpen build with CK.