### PR TITLE
Duplicate gemm solvers to support `rocBLAS` and `hipBLASLt` in in same time

### DIFF
--- a/projects/miopen/src/gemm_v2.cpp
+++ b/projects/miopen/src/gemm_v2.cpp
@@ -297,7 +297,8 @@ std::ostream& operator<<(std::ostream& stream, const GemmDescriptor& gemm_desc)
                   << "beta " << gemm_desc.beta << ", "
                   << "dataType " << GetDataType(gemm_desc.dataType) << ", "
                   << "a_cast_type " << GetDataType(gemm_desc.a_cast_type) << ", "
-                  << "b_cast_type " << GetDataType(gemm_desc.b_cast_type) << "} ";
+                  << "b_cast_type " << GetDataType(gemm_desc.b_cast_type) << ", "
+                  << "backend " << gemm_desc.gemm_backend <<"} ";
 }
 
 #if MIOPEN_USE_ROCBLAS

--- a/projects/miopen/src/include/miopen/conv/solvers.hpp
+++ b/projects/miopen/src/include/miopen/conv/solvers.hpp
@@ -4931,6 +4931,7 @@ private:
 };
 
 
+// GemmFwd + hipblaslt
 struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_2_hipblaslt : public GemmFwd1x1_0_2 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwd1x1_0_2_hipblaslt>(); }
 
@@ -4955,8 +4956,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmFwdRest_hipblaslt : public GemmFwdRest {
     const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
 };
 
-
-
+// GemmBwd + hipblaslt
 struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride2_hipblaslt : public GemmBwd1x1_stride2 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmBwd1x1_stride2_hipblaslt>(); }
 
@@ -4975,7 +4975,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmBwdRest_hipblaslt : public GemmBwdRest {
     const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
 };
 
-
+// GemmWrw + hipblaslt
 struct MIOPEN_INTERNALS_EXPORT GemmWrw1x1_stride1_hipblaslt : public GemmWrw1x1_stride1 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmWrw1x1_stride1_hipblaslt>(); }
 

--- a/projects/miopen/src/include/miopen/conv/solvers.hpp
+++ b/projects/miopen/src/include/miopen/conv/solvers.hpp
@@ -35,6 +35,7 @@
 #include <miopen/miopen.h>
 #include <miopen/performance_config.hpp>
 #include <miopen/solver.hpp>
+#include <miopen/gemm_v2.hpp>
 
 #include <initializer_list>
 #include <string>
@@ -2888,6 +2889,8 @@ struct GemmFwdBase : ConvSolver
     bool IsDynamic() const override { return true; }
     float GetWti(const ExecutionContext&, const miopen::conv::ProblemDescription&) const override;
 
+    virtual const GemmBackend_t GetGemmBackend() const { return GemmBackend_t::rocblas; }
+
 private:
     bool IsApplicable(const ExecutionContext&,
                       const miopen::conv::ProblemDescription&) const override;
@@ -2896,9 +2899,14 @@ private:
     friend struct GemmFwd1x1_0_1_int8;
     friend struct GemmFwd1x1_0_1;
     friend struct GemmFwdRest;
+
+    friend struct GemmFwd1x1_0_2_hipblaslt;
+    friend struct GemmFwd1x1_0_1_int8_hipblaslt;
+    friend struct GemmFwd1x1_0_1_hipblaslt;
+    friend struct GemmFwdRest_hipblaslt;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_2 final : GemmFwdBase
+struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_2 : GemmFwdBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwd1x1_0_2>(); }
 
@@ -2916,7 +2924,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_2 final : GemmFwdBase
     friend struct GemmFwdRest;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1_int8 final : GemmFwdBase
+struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1_int8 : GemmFwdBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwd1x1_0_1_int8>(); }
 
@@ -2934,7 +2942,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1_int8 final : GemmFwdBase
     friend struct GemmFwdRest;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1 final : GemmFwdBase
+struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1 : GemmFwdBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwd1x1_0_1>(); }
 
@@ -2952,7 +2960,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1 final : GemmFwdBase
     friend struct GemmFwdRest;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmFwdRest final : GemmFwdBase
+struct MIOPEN_INTERNALS_EXPORT GemmFwdRest : GemmFwdBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwdRest>(); }
 
@@ -2973,6 +2981,8 @@ struct GemmBwdBase : ConvSolver
     bool IsDynamic() const override { return true; }
     float GetWti(const ExecutionContext&, const miopen::conv::ProblemDescription&) const override;
 
+    virtual const GemmBackend_t GetGemmBackend() const { return GemmBackend_t::rocblas; }
+
 private:
     bool IsApplicable(const ExecutionContext&,
                       const miopen::conv::ProblemDescription&) const override;
@@ -2980,9 +2990,13 @@ private:
     friend struct GemmBwd1x1_stride2;
     friend struct GemmBwd1x1_stride1;
     friend struct GemmBwdRest;
+
+    friend struct GemmBwd1x1_stride2_hipblaslt;
+    friend struct GemmBwd1x1_stride1_hipblaslt;
+    friend struct GemmBwdRest_hipblaslt;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride2 final : GemmBwdBase
+struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride2 : GemmBwdBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmBwd1x1_stride2>(); }
 
@@ -3000,7 +3014,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride2 final : GemmBwdBase
     friend struct GemmBwdRest;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride1 final : GemmBwdBase
+struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride1 : GemmBwdBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmBwd1x1_stride1>(); }
 
@@ -3018,7 +3032,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride1 final : GemmBwdBase
     friend struct GemmBwdRest;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmBwdRest final : GemmBwdBase
+struct MIOPEN_INTERNALS_EXPORT GemmBwdRest : GemmBwdBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmBwdRest>(); }
 
@@ -3039,15 +3053,20 @@ struct GemmWrwBase : ConvSolver
     bool IsDynamic() const override { return true; }
     float GetWti(const ExecutionContext&, const miopen::conv::ProblemDescription&) const override;
 
+    virtual const GemmBackend_t GetGemmBackend() const { return GemmBackend_t::rocblas; }
+
 private:
     bool IsApplicable(const ExecutionContext&,
                       const miopen::conv::ProblemDescription&) const override;
 
     friend struct GemmWrw1x1_stride1;
     friend struct GemmWrwUniversal;
+
+    friend struct GemmWrw1x1_stride1_hipblaslt;
+    friend struct GemmWrwUniversal_hipblaslt;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmWrw1x1_stride1 final : GemmWrwBase
+struct MIOPEN_INTERNALS_EXPORT GemmWrw1x1_stride1 : GemmWrwBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmWrw1x1_stride1>(); }
 
@@ -3060,7 +3079,7 @@ struct MIOPEN_INTERNALS_EXPORT GemmWrw1x1_stride1 final : GemmWrwBase
     friend struct GemmWrwUniversal;
 };
 
-struct MIOPEN_INTERNALS_EXPORT GemmWrwUniversal final : GemmWrwBase
+struct MIOPEN_INTERNALS_EXPORT GemmWrwUniversal : GemmWrwBase
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<GemmWrwUniversal>(); }
 
@@ -4910,6 +4929,65 @@ private:
     template <typename DataType>
     bool CheckCKApplicability(const miopen::conv::ProblemDescription&) const;
 };
+
+
+struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_2_hipblaslt : public GemmFwd1x1_0_2 {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwd1x1_0_2_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1_int8_hipblaslt : public GemmFwd1x1_0_1_int8 {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwd1x1_0_1_int8_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+struct MIOPEN_INTERNALS_EXPORT GemmFwd1x1_0_1_hipblaslt : public GemmFwd1x1_0_1 {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwd1x1_0_1_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+struct MIOPEN_INTERNALS_EXPORT GemmFwdRest_hipblaslt : public GemmFwdRest {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmFwdRest_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+
+
+struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride2_hipblaslt : public GemmBwd1x1_stride2 {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmBwd1x1_stride2_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+struct MIOPEN_INTERNALS_EXPORT GemmBwd1x1_stride1_hipblaslt : public GemmBwd1x1_stride1 {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmBwd1x1_stride1_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+struct MIOPEN_INTERNALS_EXPORT GemmBwdRest_hipblaslt : public GemmBwdRest {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmBwdRest_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+
+struct MIOPEN_INTERNALS_EXPORT GemmWrw1x1_stride1_hipblaslt : public GemmWrw1x1_stride1 {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmWrw1x1_stride1_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
+struct MIOPEN_INTERNALS_EXPORT GemmWrwUniversal_hipblaslt : public GemmWrwUniversal {
+    const std::string& SolverDbId() const override { return GetSolverDbId<GemmWrwUniversal_hipblaslt>(); }
+
+    const GemmBackend_t GetGemmBackend() const override { return GemmBackend_t::hipblaslt; }
+};
+
 
 } // namespace conv
 } // namespace solver

--- a/projects/miopen/src/include/miopen/gemm_v2.hpp
+++ b/projects/miopen/src/include/miopen/gemm_v2.hpp
@@ -72,6 +72,7 @@ struct GemmDescriptor
     miopenDataType_t a_cast_type;
     miopenDataType_t b_cast_type;
     ConvolutionAttribute conv_attributes;
+    GemmBackend_t gemm_backend;
     GemmDescriptor() = delete;
     GemmDescriptor(bool isColMajor_,
                    bool transA_,
@@ -89,7 +90,8 @@ struct GemmDescriptor
                    float alpha_,
                    float beta_,
                    miopenDataType_t dataType_,
-                   bool deterministic_)
+                   bool deterministic_,
+                   GemmBackend_t gemm_backend_ = GemmBackend_t::rocblas)
         : isColMajor(isColMajor_),
           transA(transA_),
           transB(transB_),
@@ -109,7 +111,8 @@ struct GemmDescriptor
           deterministic(deterministic_),
           gfx90a_alt_impl(false),
           a_cast_type(dataType),
-          b_cast_type(dataType)
+          b_cast_type(dataType),
+          gemm_backend(gemm_backend_)
     {
     }
 

--- a/projects/miopen/src/mlo_dir_conv.cpp
+++ b/projects/miopen/src/mlo_dir_conv.cpp
@@ -61,12 +61,25 @@ static auto GetGemmSolvers()
                                            miopen::solver::conv::GemmFwd1x1_0_2,
                                            miopen::solver::conv::GemmFwdRest,
 
+                                           miopen::solver::conv::GemmFwd1x1_0_1_hipblaslt,
+                                           miopen::solver::conv::GemmFwd1x1_0_1_int8_hipblaslt,
+                                           miopen::solver::conv::GemmFwd1x1_0_2_hipblaslt,
+                                           miopen::solver::conv::GemmFwdRest_hipblaslt,
+
                                            miopen::solver::conv::GemmBwd1x1_stride1,
                                            miopen::solver::conv::GemmBwd1x1_stride2,
                                            miopen::solver::conv::GemmBwdRest,
 
+                                           miopen::solver::conv::GemmBwd1x1_stride1_hipblaslt,
+                                           miopen::solver::conv::GemmBwd1x1_stride2_hipblaslt,
+                                           miopen::solver::conv::GemmBwdRest_hipblaslt,
+
                                            miopen::solver::conv::GemmWrw1x1_stride1,
-                                           miopen::solver::conv::GemmWrwUniversal>{};
+                                           miopen::solver::conv::GemmWrwUniversal,
+
+                                           miopen::solver::conv::GemmWrw1x1_stride1_hipblaslt,
+                                           miopen::solver::conv::GemmWrwUniversal_hipblaslt
+                                           >{};
 }
 
 static auto GetDirectSolvers()

--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -724,6 +724,18 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
              Primitive::Fusion,
              fusion::ConvCKIgemmGrpFwdActivFused{}.SolverDbId(),
              miopenConvolutionAlgoImplicitGEMM);
+
+    RegisterWithSolver(registry, ++id, conv::GemmFwd1x1_0_1_hipblaslt{}, miopenConvolutionAlgoGEMM);
+    RegisterWithSolver(registry, ++id, conv::GemmFwd1x1_0_1_int8_hipblaslt{}, miopenConvolutionAlgoGEMM);
+    RegisterWithSolver(registry, ++id, conv::GemmFwd1x1_0_2_hipblaslt{}, miopenConvolutionAlgoGEMM);
+    RegisterWithSolver(registry, ++id, conv::GemmFwdRest_hipblaslt{}, miopenConvolutionAlgoGEMM);
+
+    RegisterWithSolver(registry, ++id, conv::GemmBwd1x1_stride2_hipblaslt{}, miopenConvolutionAlgoGEMM);
+    RegisterWithSolver(registry, ++id, conv::GemmBwd1x1_stride1_hipblaslt{}, miopenConvolutionAlgoGEMM);
+    RegisterWithSolver(registry, ++id, conv::GemmBwdRest_hipblaslt{}, miopenConvolutionAlgoGEMM);
+
+    RegisterWithSolver(registry, ++id, conv::GemmWrw1x1_stride1_hipblaslt{}, miopenConvolutionAlgoGEMM);
+    RegisterWithSolver(registry, ++id, conv::GemmWrwUniversal_hipblaslt{}, miopenConvolutionAlgoGEMM);
     // IMPORTANT: New solvers should be added to the end of the function, and don't leave a white
     // space between this comment and the newly registered solver(s)!
 }

--- a/projects/miopen/src/solver/conv/gemm.cpp
+++ b/projects/miopen/src/solver/conv/gemm.cpp
@@ -255,6 +255,9 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
     decltype(auto) wDesc = problem.GetWeights();
     decltype(auto) yDesc = problem.GetOut();
 
+    MIOPEN_LOG_I2("GemmFwd1x1_0_2 GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     const GemmDescriptor tmp_gemm_desc = [&]() {
         auto tmp          = conv.group_count > 1
                                 ? CreateGemmDescriptorGroupConvCNHWFwd(wDesc, xDesc, yDesc, conv.group_count)
@@ -269,6 +272,7 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
                 tmp.b_cast_type = *xDesc.GetCastType();
         }
         tmp.conv_attributes = problem.GetConv().attribute;
+        tmp.gemm_backend = gemm_backend;
         return tmp;
     }();
 
@@ -382,7 +386,7 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
                                                      0,
                                                      workSpace,
                                                      x_t_size,
-                                                     GemmBackend_t::rocblas);
+                                                     gemm_backend);
             }
             else
             {
@@ -395,7 +399,7 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
                                        wksp_offset,
                                        workSpace,
                                        x_t_size,
-                                       GemmBackend_t::rocblas);
+                                       gemm_backend);
             }
 
             if(gemm_status != miopenStatusSuccess)
@@ -536,6 +540,9 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
     auto solution         = ConvSolution{miopenStatusSuccess};
     solution.workspace_sz = workspace_req;
 
+    MIOPEN_LOG_I2("GemmFwd1x1_0_1_int8 GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     TensorDescriptor ygemmDesc(miopenInt32, yDesc.GetLengths(), yDesc.GetStrides());
     const GemmDescriptor tmp_gemm_desc = [&]() {
         auto tmp          = CreateGemmDescriptorConvFwd(wDesc, xDesc, yDesc);
@@ -549,6 +556,7 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
                 tmp.b_cast_type = *wDesc.GetCastType();
         }
         tmp.conv_attributes = problem.GetConv().attribute;
+        tmp.gemm_backend = gemm_backend;
         return tmp;
     }();
     const auto x_type     = xDesc.GetType();
@@ -600,7 +608,7 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
                     time += handle.GetKernelTime();
 
                 gemm_status = CallGemm(
-                    handle, gemm_desc, w, 0, workSpace, 0, y, out_offset, GemmBackend_t::rocblas);
+                    handle, gemm_desc, w, 0, workSpace, 0, y, out_offset, gemm_backend);
 
                 if(gemm_status != miopenStatusSuccess)
                     MIOPEN_THROW("GEMM execution failure");
@@ -682,6 +690,9 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
 
     const auto group_count = conv.group_count;
 
+    MIOPEN_LOG_I2("GemmFwd1x1_0_1 GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     if(group_count > 1)
     {
         const GemmDescriptor tmp_gemm_desc = [&]() {
@@ -696,6 +707,7 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
                     tmp.b_cast_type = *xDesc.GetCastType();
             }
             tmp.conv_attributes = problem.GetConv().attribute;
+            tmp.gemm_backend = gemm_backend;
             return tmp;
         }();
 
@@ -741,7 +753,7 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
                                                          in_offset,
                                                          y,
                                                          out_offset,
-                                                         GemmBackend_t::rocblas);
+                                                         gemm_backend);
 
                     if(gemm_status != miopenStatusSuccess)
                         MIOPEN_THROW("GEMM execution failure");
@@ -773,6 +785,7 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
                     tmp.b_cast_type = *xDesc.GetCastType();
             }
             tmp.conv_attributes = problem.GetConv().attribute;
+            tmp.gemm_backend = gemm_backend;
             return tmp;
         }();
 
@@ -801,7 +814,7 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
                 }();
 
                 gemm_status = CallGemmStridedBatched(
-                    handle, gemm_desc, w, 0, x, 0, y, 0, GemmBackend_t::rocblas);
+                    handle, gemm_desc, w, 0, x, 0, y, 0, gemm_backend);
 
                 if(gemm_status != miopenStatusSuccess)
                     MIOPEN_THROW("GEMM execution failure");
@@ -901,6 +914,9 @@ ConvSolution GemmFwdRest::GetSolution(const ExecutionContext& context,
     auto solution         = ConvSolution{miopenStatusSuccess};
     solution.workspace_sz = workspace_req;
 
+    MIOPEN_LOG_I2("GemmFwdRest GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
         const auto tmp_gemm_desc = [&]() {
             auto tmp          = conv.group_count > 1
@@ -916,6 +932,7 @@ ConvSolution GemmFwdRest::GetSolution(const ExecutionContext& context,
                     tmp.b_cast_type = *xDesc.GetCastType();
             }
             tmp.conv_attributes = problem.GetConv().attribute;
+            tmp.gemm_backend = gemm_backend;
             return tmp;
         }();
 
@@ -1013,7 +1030,7 @@ ConvSolution GemmFwdRest::GetSolution(const ExecutionContext& context,
                                                          0,
                                                          y,
                                                          out_offset,
-                                                         GemmBackend_t::rocblas);
+                                                         gemm_backend);
                 }
                 else
                 {
@@ -1025,7 +1042,7 @@ ConvSolution GemmFwdRest::GetSolution(const ExecutionContext& context,
                                            wksp_offset,
                                            y,
                                            out_offset,
-                                           GemmBackend_t::rocblas);
+                                           gemm_backend);
                 }
 
                 if(gemm_status != miopenStatusSuccess)

--- a/projects/miopen/src/solver/conv/gemm_bwd.cpp
+++ b/projects/miopen/src/solver/conv/gemm_bwd.cpp
@@ -230,6 +230,9 @@ ConvSolution GemmBwd1x1_stride2::GetSolution(const ExecutionContext& context,
 
     const auto group_count = conv.group_count;
 
+    MIOPEN_LOG_I2("GemmBwd1x1_stride2 GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     GemmDescriptor tmp_gemm_desc = [&]() {
         auto tmp =
             group_count > 1
@@ -245,6 +248,7 @@ ConvSolution GemmBwd1x1_stride2::GetSolution(const ExecutionContext& context,
                 tmp.b_cast_type = *dyDesc.GetCastType();
         }
         tmp.conv_attributes = problem.GetConv().attribute;
+        tmp.gemm_backend = gemm_backend;
         return tmp;
     }();
     std::size_t in_n, in_c;
@@ -335,7 +339,7 @@ ConvSolution GemmBwd1x1_stride2::GetSolution(const ExecutionContext& context,
                                                      0,
                                                      workspace,
                                                      dyDesc_.GetElementSize(),
-                                                     GemmBackend_t::rocblas);
+                                                     gemm_backend);
             }
             else
             {
@@ -348,7 +352,7 @@ ConvSolution GemmBwd1x1_stride2::GetSolution(const ExecutionContext& context,
                                        0,
                                        workspace,
                                        dyDesc_.GetElementSize(),
-                                       GemmBackend_t::rocblas);
+                                       gemm_backend);
             }
 
             if(gemm_status != miopenStatusSuccess)
@@ -425,6 +429,9 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
     const auto group_count = problem.GetConv().group_count;
     const auto spatial_dim = problem.GetConv().GetSpatialDimension();
 
+    MIOPEN_LOG_I2("GemmBwd1x1_stride1 GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     auto solution         = ConvSolution{miopenStatusSuccess};
     solution.workspace_sz = 0;
 
@@ -456,6 +463,7 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
                         tmp.b_cast_type = *dyDesc.GetCastType();
                 }
                 tmp.conv_attributes = problem.GetConv().attribute;
+                tmp.gemm_backend = gemm_backend;
                 return tmp;
             }();
 
@@ -510,7 +518,7 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
                                                          out_offset,
                                                          dx,
                                                          in_offset,
-                                                         GemmBackend_t::rocblas);
+                                                         gemm_backend);
 
                     if(handle.IsProfilingEnabled())
                         time += handle.GetKernelTime();
@@ -524,7 +532,7 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
             else
             {
                 gemm_status = CallGemmStridedBatched(
-                    handle, gemm_desc, w, 0, dy, 0, dx, 0, GemmBackend_t::rocblas);
+                    handle, gemm_desc, w, 0, dy, 0, dx, 0, gemm_backend);
             }
 
             if(gemm_status != miopenStatusSuccess)
@@ -617,6 +625,9 @@ ConvSolution GemmBwdRest::GetSolution(const ExecutionContext& context,
     const auto wei_spatial  = std::vector<std::size_t>(wei_spatial_.begin(), wei_spatial_.end());
     const auto out_spatial  = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
 
+    MIOPEN_LOG_I2("GemmBwdRest GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     // dx = transpose(w) * dy
     const auto tmp_gemm_desc = [&]() {
         auto tmp          = group_count > 1
@@ -632,6 +643,7 @@ ConvSolution GemmBwdRest::GetSolution(const ExecutionContext& context,
                 tmp.b_cast_type = *dyDesc.GetCastType();
         }
         tmp.conv_attributes = problem.GetConv().attribute;
+        tmp.gemm_backend = gemm_backend;
         return tmp;
     }();
     const auto spatial_dims = conv.GetSpatialDimension();
@@ -705,7 +717,7 @@ ConvSolution GemmBwdRest::GetSolution(const ExecutionContext& context,
                                                          out_offset,
                                                          workspace,
                                                          0,
-                                                         GemmBackend_t::rocblas);
+                                                         gemm_backend);
                 }
                 else
                 {
@@ -717,7 +729,7 @@ ConvSolution GemmBwdRest::GetSolution(const ExecutionContext& context,
                                            out_offset,
                                            workspace,
                                            0,
-                                           GemmBackend_t::rocblas);
+                                           gemm_backend);
                 }
 
                 if(gemm_status != miopenStatusSuccess)

--- a/projects/miopen/src/solver/conv/gemm_wrw.cpp
+++ b/projects/miopen/src/solver/conv/gemm_wrw.cpp
@@ -185,6 +185,9 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
         MIOPEN_LOG_FUNCTION("convolution, 1x1");
     }
 
+    MIOPEN_LOG_I2("GemmBwd1x1_stride2 GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     // dw = sum_over_batch(dy[i] * transpose(x[i])), i is batch id
     const auto tmp_gemm_desc = [&]() {
         auto tmp          = group_count > 1
@@ -200,6 +203,7 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
                 tmp.b_cast_type = *xDesc.GetCastType();
         }
         tmp.conv_attributes = problem.GetConv().attribute;
+        tmp.gemm_backend = gemm_backend;
         return tmp;
     }();
 
@@ -265,7 +269,7 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
                                                                in_offset,
                                                                dw,
                                                                0,
-                                                               GemmBackend_t::rocblas);
+                                                               gemm_backend);
 
                     if(status != miopenStatusSuccess)
                         MIOPEN_THROW("GemmWrw1x1_stride1 execution failure.");
@@ -284,7 +288,7 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
             {
                 // dw = sum_over_batch(dy[i] * transpose(x[i])), i is batch id
                 const auto status = CallGemmStridedBatchedSequential(
-                    handle, gemm_desc, dy, 0, x, 0, dw, 0, GemmBackend_t::rocblas);
+                    handle, gemm_desc, dy, 0, x, 0, dw, 0, gemm_backend);
 
                 if(status != miopenStatusSuccess)
                     MIOPEN_THROW("GemmWrw1x1_stride1 execution failure.");
@@ -364,6 +368,9 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
     const auto& conv       = problem.GetConv();
     const auto group_count = conv.group_count;
 
+    MIOPEN_LOG_I2("GemmBwd1x1_stride2 GemmBackend : " << static_cast<int>(GetGemmBackend()));
+    const auto gemm_backend = GetGemmBackend();
+
     // dw = dy * transpose(Im2Col(x))
     const auto tmp_gemm_desc = [&]() {
         auto tmp          = group_count > 1
@@ -379,6 +386,7 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
                 tmp.b_cast_type = *xDesc.GetCastType();
         }
         tmp.conv_attributes = problem.GetConv().attribute;
+        tmp.gemm_backend = gemm_backend;
         return tmp;
     }();
 
@@ -481,7 +489,7 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
                                                     0,
                                                     dw,
                                                     0,
-                                                    GemmBackend_t::rocblas);
+                                                    gemm_backend);
                 }
                 else
                 {
@@ -494,7 +502,7 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
                                       0,
                                       dw,
                                       0,
-                                      GemmBackend_t::rocblas);
+                                      gemm_backend);
                 }
 
                 if(status != miopenStatusSuccess)


### PR DESCRIPTION
Duplicate gemm solvers to support `rocBLAS` and `hipBLASLt` in in same time. 

- The gemm backend is selected via env var `MIOPEN_GEMM_ENFORCE_BACKEND` and default is rocBLAS
- With this submit, we could use `rocBLAS` and `hipBLASLt` for solver in in same time. 
- No obvious performance improvement or degradation was observed in this submission.



## MIOpen commands that select hipBLASLt kernel for `SD1.5`.
A total of 49 MIOpen commands were executed when running `inf_sd15.py`.
The following commands select the hipBLASLt kernel in Strix Halo:

- Wth this submit    : `average latency: 3.296577 s`
- Without this submit : `average latency: 3.367865 s`

```
MIOpenDriver.exe convfp16 -n 2 -c 640 -H 32 -W 32 -k 640 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 640 -H 32 -W 32 -k 640 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 1280 -H 16 -W 16 -k 1280 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 4 -H 64 -W 64 -k 4 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 3 -H 224 -W 224 -k 1024 -y 14 -x 14 -p 0 -q 0 -u 14 -v 14 -l 1 -j 1 -m conv -g 1 -F 1 -t 1

```

## MIOpen commands that select hipBLASLt kernel for `controlnet-inpaint`.
A total of 68 MIOpen commands were executed when running `inf_inpaint.py`.
The following commands select the hipBLASLt kernel in Strix Halo:

- Wth this submit    : `average latency: 4.746146 s`
- Without this submit : `average latency: 4.757505 s`

```
MIOpenDriver.exe convfp16 -n 1 -c 8 -H 64 -W 64 -k 8 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 640 -H 32 -W 32 -k 640 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 1280 -H 16 -W 16 -k 1280 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 1280 -H 8 -W 8 -k 1280 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 640 -H 16 -W 16 -k 640 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 4 -H 64 -W 64 -k 4 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
```

## MIOpen commands that select hipBLASLt kernel for `controlnet-scribble`.
A total of 58 MIOpen commands were executed when running `inf_scribble.py`.
The following commands select the hipBLASLt kernel in Strix Halo:

- Wth this submit    : `average latency: 5.035928 s`
- Without this submit : `average latency: 4.988400 s`

```
MIOpenDriver.exe convfp16 -n 2 -c 640 -H 32 -W 32 -k 640 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 1280 -H 16 -W 16 -k 1280 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 1280 -H 8 -W 8 -k 1280 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 320 -H 32 -W 32 -k 320 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 4 -H 64 -W 64 -k 4 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
```

## MIOpen commands that select hipBLASLt kernel for `controlnet-segment`.
A total of 58 MIOpen commands were executed when running `inf_segment.py`.
The following commands select the hipBLASLt kernel in Strix Halo:

- Wth this submit    : `average latency: 4.498638 s`
- Without this submit : `average latency: 4.605161 s`

```
MIOpenDriver.exe convfp16 -n 2 -c 640 -H 32 -W 32 -k 640 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 2560 -H 8 -W 8 -k 1280 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 4 -H 64 -W 64 -k 4 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
```


## MIOpen commands that select hipBLASLt kernel for `controlnet-shuffle`.
A total of 74 MIOpen commands were executed when running `inf_shuffle.py`.
The following commands select the hipBLASLt kernel in Strix Halo:

- Wth this submit    : `average latency: 3.957070 s`
- Without this submit : `average latency: 4.074917 s`


```
MIOpenDriver.exe convfp16 -n 1 -c 640 -H 32 -W 32 -k 640 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 1280 -H 16 -W 16 -k 1280 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 1280 -H 16 -W 16 -k 1280 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 1280 -H 8 -W 8 -k 1280 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 640 -H 16 -W 16 -k 640 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 640 -H 32 -W 32 -k 640 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 2 -c 2560 -H 8 -W 8 -k 1280 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
MIOpenDriver.exe convfp16 -n 1 -c 4 -H 64 -W 64 -k 4 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1
```

## MIOpen commands that select hipBLASLt for `upscale`.
No MIOpen commands select hipBLASLt kernel for this case

## MIOpen commands that use hipBLASLt for `blip`.
No MIOpen commands select hipBLASLt kernel for this case

## MIOpen commands that use hipBLASLt for `argos`.
No MIOpen commands select hipBLASLt kernel for this case





