### PR TITLE
Add CK support for GFX1151

### DIFF
--- a/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
@@ -41,9 +41,9 @@ namespace ck_utility {
 /// instance for the device.
 static inline bool is_ck_whitelist(const std::string& device_name)
 {
-    return true;
-    // return (StartsWith(device_name, "gfx908") || StartsWith(device_name, "gfx90a") ||
-    //         StartsWith(device_name, "gfx942") || StartsWith(device_name, "gfx950"));
+    return (StartsWith(device_name, "gfx908") || StartsWith(device_name, "gfx90a") ||
+            StartsWith(device_name, "gfx942") || StartsWith(device_name, "gfx950") ||
+            StartsWith(device_name, "gfx1151"));
 }
 
 static inline bool is_ck_whitelist(const Handle& handle)

--- a/projects/miopen/src/include/miopen/solver/implicitgemm_util.hpp
+++ b/projects/miopen/src/include/miopen/solver/implicitgemm_util.hpp
@@ -100,7 +100,8 @@ static inline bool IsXdlopsSupport(const ExecutionContext& ctx)
     // 2) llvm intrin may has incorrect results
     const bool is_xdlops_supported = ctx.GetStream().GetDeviceName() == "gfx908" ||
                                      ctx.GetStream().GetDeviceName() == "gfx90a" ||
-                                     ctx.GetStream().GetDeviceName() == "gfx942";
+                                     ctx.GetStream().GetDeviceName() == "gfx942" ||
+                                     ctx.GetStream().GetDeviceName() == "gfx1151";
     return is_xdlops_supported && !env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS);
 }
 

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -33,12 +33,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 
-// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
-#ifdef MIOPEN_USE_COMPOSABLEKERNEL
-#undef MIOPEN_USE_COMPOSABLEKERNEL
-#define MIOPEN_USE_COMPOSABLEKERNEL 0
-#endif
-
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
 #include <ck/library/tensor_operation_instance/gpu/grouped_convolution_backward_data_bilinear.hpp>

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -33,12 +33,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 
-// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
-#ifdef MIOPEN_USE_COMPOSABLEKERNEL
-#undef MIOPEN_USE_COMPOSABLEKERNEL
-#define MIOPEN_USE_COMPOSABLEKERNEL 0
-#endif
-
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
 #include <ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_bilinear.hpp>
@@ -382,7 +376,7 @@ void PerformanceConfigHipImplicitGemm3DGroupFwdXdlops::Init(const ProblemDescrip
             return static_cast<std::size_t>(it - valid_kernels.begin());
 
         // Not found: return 0
-        MIOPEN_LOG_E("Not found :" << index << "-" << kernel_id);
+        MIOPEN_LOG_W("Not found :" << index << "-" << kernel_id);
         return 0;
     };
 

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -376,7 +376,7 @@ void PerformanceConfigHipImplicitGemm3DGroupFwdXdlops::Init(const ProblemDescrip
             return static_cast<std::size_t>(it - valid_kernels.begin());
 
         // Not found: return 0
-        MIOPEN_LOG_W("Not found :" << index << "-" << kernel_id);
+        MIOPEN_LOG_I("Not found :" << index << "-" << kernel_id);
         return 0;
     };
 

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -33,12 +33,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 
-// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
-#ifdef MIOPEN_USE_COMPOSABLEKERNEL
-#undef MIOPEN_USE_COMPOSABLEKERNEL
-#define MIOPEN_USE_COMPOSABLEKERNEL 0
-#endif
-
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <ck/library/tensor_operation_instance/gpu/convolution_backward_data.hpp>
 #include <miopen/solver/ck_utility_common.hpp>

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -33,12 +33,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 
-// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
-#ifdef MIOPEN_USE_COMPOSABLEKERNEL
-#undef MIOPEN_USE_COMPOSABLEKERNEL
-#define MIOPEN_USE_COMPOSABLEKERNEL 0
-#endif
-
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <ck/library/tensor_operation_instance/gpu/convolution_forward.hpp>
 #include <miopen/solver/ck_utility_common.hpp>

--- a/projects/miopen/src/solver/conv/gemm.cpp
+++ b/projects/miopen/src/solver/conv/gemm.cpp
@@ -857,12 +857,12 @@ size_t GemmFwdRest::GetWorkspaceSize(const ExecutionContext& context,
 
     const auto ws_sz = (wDesc.GetType() == miopenInt8 ? 2 * workspace_size : workspace_size);
 
-    // if(ws_sz > gemm::MaxMemAllocSz(handle, problem, true))
-    // {
-    //     MIOPEN_LOG_I2("GemmFwdRest: " << ws_sz << " > "
-    //                                   << gemm::MaxMemAllocSz(handle, problem, true));
-    //     return 0;
-    // }
+    if(ws_sz > gemm::MaxMemAllocSz(handle, problem, true))
+    {
+        MIOPEN_LOG_I2("GemmFwdRest: " << ws_sz << " > "
+                                      << gemm::MaxMemAllocSz(handle, problem, true));
+        return 0;
+    }
     return ws_sz;
 #else
     std::ignore = context;

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
@@ -35,12 +35,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 
-// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
-#ifdef MIOPEN_USE_COMPOSABLEKERNEL
-#undef MIOPEN_USE_COMPOSABLEKERNEL
-#define MIOPEN_USE_COMPOSABLEKERNEL 0
-#endif
-
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp>
 #endif
@@ -443,7 +437,7 @@ bool ConvCKIgemmFwdBiasActivFused::IsApplicable(const FusionContext& ctx,
     if(!conv_problem.Is2d())
         return false;
     const std::string arch = ctx.GetStream().GetDeviceName();
-    if(arch != "gfx908" && arch != "gfx90a" && arch != "gfx942")
+    if(arch != "gfx908" && arch != "gfx90a" && arch != "gfx942" && arch != "gfx1151")
         return false;
     if(!conv_problem.IsLayoutNHWC())
         return false;

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
@@ -35,12 +35,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 
-// Workaround to disable CK since GFX11 doesn't support specific XDL instances.
-#ifdef MIOPEN_USE_COMPOSABLEKERNEL
-#undef MIOPEN_USE_COMPOSABLEKERNEL
-#define MIOPEN_USE_COMPOSABLEKERNEL 0
-#endif
-
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
 #include <miopen/solver/implicitgemm_ck_util.hpp>


### PR DESCRIPTION
Add CK support for GFX1151.
- Revert workaround PR #1
- Revert workaround PR #2

This submission is associated with https://github.com/klin2024/rocm-libraries/pull/5 . Please use a CK version newer than this PR.




# Build MIOpen With CK
```
cmake -G Ninja ^
  -DHIP_PLATFORM=amd ^
  -DCMAKE_BUILD_TYPE=Release ^
  -DCMAKE_C_COMPILER=%ROCM_PATH%/lib/llvm/bin/clang.exe ^
  -DCMAKE_CXX_COMPILER=%ROCM_PATH%/lib/llvm/bin/clang++.exe ^
  -DMIOPEN_BACKEND=HIP ^
  -DMIOPEN_USE_COMPOSABLEKERNEL=ON ^
  -DMIOPEN_USE_MLIR=ON ^
  -DMIOPEN_USE_HIPBLASLT=ON ^
  -DMIOPEN_TEST_GFX110X=ON ^
  -DMIOPEN_USE_ROCBLAS=ON ^
  -DMIOPEN_USE_SQLITE_PERFDB=ON ^
  -DGPU_TARGETS="gfx1151" ^
  -DCMAKE_PREFIX_PATH="C:/opt/composablekernel/Release;C:/opt/rocmlir/Release;%CD%/..//depend/Release" ^
  ..
```