### PR TITLE
Add workaround to prevent ConvHipImplicitGemm3DGroupFwdXdlops got unexcepted elapsed time

### DIFF
--- a/projects/miopen/src/conv/solver_finders.cpp
+++ b/projects/miopen/src/conv/solver_finders.cpp
@@ -328,7 +328,11 @@ std::vector<Solution> EvaluateInvokers(const Handle& handle,
                 elapsed = first_elapsed;
             }
 
-            MIOPEN_THROW_IF(elapsed <= 0, "Invalid elapsed time detected in EvaluateInvokers");
+            // MIOPEN_THROW_IF(elapsed <= 0, "Invalid elapsed time detected in EvaluateInvokers");
+            if (elapsed <= 0) {
+                MIOPEN_LOG_I("Warning! Invalid elapsed time detected for " << sol.solver_id << ". Using fallback time.");
+                elapsed = 0.00001f;     // workaround to assign the elapsed time
+            }
 
             MIOPEN_LOG_I(sol << ": " << elapsed << (elapsed < best ? " < " : " >= ") << best);
             if(elapsed < best)


### PR DESCRIPTION
Add workaround to prevent ConvHipImplicitGemm3DGroupFwdXdlops got unexcepted elapsed time

In some case, ConvHipImplicitGemm3DGroupFwdXdlops will got unexcepted elapsed time and cause MIOpen throw `No Excepted solution found` exception if we disable naive kernel.
But, the ConvHipImplicitGemm3DGroupFwdXdlops  work fine asctually. it might be some bug in time estimation or something. so we disable the throw as workaround

<img width="1911" height="407" alt="image" src="https://github.com/user-attachments/assets/f040c44a-6f56-45ba-9823-5ff819aa601b" />
